### PR TITLE
initial commits from zoom call - not passing test

### DIFF
--- a/project.py
+++ b/project.py
@@ -53,6 +53,20 @@ def convert_text_to_digits_example(text: str) -> list:
     return results
 
 
+def email_domain_and_user_count(string_of_emails):
+    dict_of_emails_and_users_count = {}
+    if not string_of_emails:
+        return dict_of_emails_and_users_count
+    list_of_emails = string_of_emails.split(',')
+    for email in list_of_emails:
+        email_domain = email.split('@')[1]
+        if email_domain not in dict_of_emails_and_users_count:
+            dict_of_emails_and_users_count[email_domain] = 1
+        else:
+            dict_of_emails_and_users_count[email_domain] += 1
+    
+    return dict_of_emails_and_users_count
+
 def show_aggie_pride():
     """Show Aggie Pride"""
     return 'Aggie Pride - Worldwide'

--- a/test_project.py
+++ b/test_project.py
@@ -1,6 +1,6 @@
 """Unit-test cases for class project"""
 import unittest
-from project import show_aggie_pride, reverse_list, get_area_codes, convert_text_numbers_to_integers, convert_text_to_digits_example
+from project import show_aggie_pride, reverse_list, get_area_codes, convert_text_numbers_to_integers, convert_text_to_digits_example, area_code_lookup
 
 
 class ProjectTestCase(unittest.TestCase):
@@ -58,6 +58,23 @@ class ProjectTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             convert_text_to_digits_example('')
 
+    def test_area_code_look(self):
+        """""Test to verify if area_code_lookup works as it should"""
+        text = '919-555-1212,212-555-1212 , 970-555-1212, 415-555-1212'
+        output_dict = {212:'NY', 415:'CA', 919:'NC', 970:'CO'}
+        self.assertEqual(output_dict, area_code_lookup(text))
+
+        #test set of other valid area codes
+        text1 = '336-554-3994, 603-554-3994, 207-654-3894, 208-654-3894'
+        output_dict1 = {207:'ME', 208:'ID', 336:'NC', 603:'NH'}
+        self.assertEqual(output_dict1, area_code_lookup(text1))
+
+        #test set of invalid area codes
+        with self.assertRaises(ValueError):
+            area_code_lookup('105-554-3994, 800-554-3994, 877-554-3994, 888-554-3994')
+
+        #test for empty list
+        with self.assertRaises(ValueError):
+            area_code_lookup('')
 if __name__ == '__main__':
     unittest.main()
-

--- a/test_project.py
+++ b/test_project.py
@@ -58,10 +58,10 @@ class ProjectTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             convert_text_to_digits_example('')
 
-    def test_email_domain_and_user_count(self):
-        text = 'joe@gmail.com, john@outlook.com , jerry@abc.com,julie@xyz.com, tim@abc.com, joe@gmail.com'
-        results = {'abc.com':2, 'gmail.com':1, 'outlook.com':1, 'xyz.com':1}
-        self.assertDictEqual(results, email_domain_and_user_count(text))
+    #def test_email_domain_and_user_count(self):
+        #text = 'joe@gmail.com, john@outlook.com , jerry@abc.com,julie@xyz.com, tim@abc.com, joe@gmail.com'
+        #results = {'abc.com':2, 'gmail.com':1, 'outlook.com':1, 'xyz.com':1}
+        #self.assertDictEqual(results, email_domain_and_user_count(text))
 
 
 if __name__ == '__main__':

--- a/test_project.py
+++ b/test_project.py
@@ -1,6 +1,6 @@
 """Unit-test cases for class project"""
 import unittest
-from project import email_domain_and_user_count, show_aggie_pride, reverse_list, get_area_codes, convert_text_numbers_to_integers, convert_text_to_digits_example
+from project import show_aggie_pride, reverse_list, get_area_codes, convert_text_numbers_to_integers, convert_text_to_digits_example
 
 
 class ProjectTestCase(unittest.TestCase):

--- a/test_project.py
+++ b/test_project.py
@@ -58,12 +58,6 @@ class ProjectTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             convert_text_to_digits_example('')
 
-    #def test_email_domain_and_user_count(self):
-        #text = 'joe@gmail.com, john@outlook.com , jerry@abc.com,julie@xyz.com, tim@abc.com, joe@gmail.com'
-        #results = {'abc.com':2, 'gmail.com':1, 'outlook.com':1, 'xyz.com':1}
-        #self.assertDictEqual(results, email_domain_and_user_count(text))
-
-
 if __name__ == '__main__':
     unittest.main()
 

--- a/test_project.py
+++ b/test_project.py
@@ -1,6 +1,6 @@
 """Unit-test cases for class project"""
 import unittest
-from project import show_aggie_pride, reverse_list, get_area_codes, convert_text_numbers_to_integers, convert_text_to_digits_example
+from project import email_domain_and_user_count, show_aggie_pride, reverse_list, get_area_codes, convert_text_numbers_to_integers, convert_text_to_digits_example
 
 
 class ProjectTestCase(unittest.TestCase):
@@ -57,6 +57,11 @@ class ProjectTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             convert_text_to_digits_example('')
+
+    def test_email_domain_and_user_count(self):
+        text = 'joe@gmail.com, john@outlook.com , jerry@abc.com,julie@xyz.com, tim@abc.com, joe@gmail.com'
+        results = {'abc.com':2, 'gmail.com':1, 'outlook.com':1, 'xyz.com':1}
+        self.assertDictEqual(results, email_domain_and_user_count(text))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added the code we developed together from our zoom call but is not passing test cases 

following error:

./test_project.py::ProjectTestCase::test_email_domain_and_user_count Failed: {'abc.com': 2, 'gmail.com': 1, 'outlook.com': 1, 'xyz.com': 1} != {'gmail.com': 2, 'outlook.com ': 1, 'abc.com': 2, 'xyz.com': 1}
- {'abc.com': 2, 'gmail.com': 1, 'outlook.com': 1, 'xyz.com': 1}
?                             ^

+ {'abc.com': 2, 'gmail.com': 2, 'outlook.com ': 1, 'xyz.com': 1}
?                             ^              +

  File "/usr/local/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/usr/local/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/usr/local/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/workspaces/comp410_spring_2023/test_project.py", line 64, in test_email_domain_and_user_count
    self.assertDictEqual(results, email_domain_and_user_count(text))
AssertionError: {'abc.com': 2, 'gmail.com': 1, 'outlook.com': 1, 'xyz.com': 1} != {'gmail.com': 2, 'outlook.com ': 1, 'abc.com': 2, 'xyz.com': 1}
- {'abc.com': 2, 'gmail.com': 1, 'outlook.com': 1, 'xyz.com': 1}
?                             ^
+ {'abc.com': 2, 'gmail.com': 2, 'outlook.com ': 1, 'xyz.com': 1}
?                             ^              +
